### PR TITLE
Remove redundant import

### DIFF
--- a/src/main/java/nl/jqno/equalsverifier/EqualsVerifierApi.java
+++ b/src/main/java/nl/jqno/equalsverifier/EqualsVerifierApi.java
@@ -6,7 +6,6 @@ import nl.jqno.equalsverifier.internal.checkers.*;
 import nl.jqno.equalsverifier.internal.exceptions.MessagingException;
 import nl.jqno.equalsverifier.internal.prefabvalues.FactoryCache;
 import nl.jqno.equalsverifier.internal.util.*;
-import nl.jqno.equalsverifier.internal.util.Formatter;
 
 import java.util.*;
 


### PR DESCRIPTION
# What problem does this pull request solve?

Removes redundant import so this project can pass Checkstyle check after RedundantImportCheck is fixed in Checkstyle project

# Please provide any additional information below.

I am working on [pull request](https://github.com/checkstyle/checkstyle/pull/6461) in Checkstyle project that fixes a bug in RedundantImportCheck check. Currently, this check does not detect some redundant imports ([more info](https://github.com/checkstyle/checkstyle/issues/6450)). The thing is, it turns out that Checkstyle project uses some open source projects (like this one) to test their code on and they want no checkstyle violations in these projects before they accept pull requests. It turns out that this project actually has one Checkstyle violation, that gets detected by improved version of RedundantImportCheck (after my fix). So, in order to make my pull request get accepted the violation in this project needs to get fixed first.

Problematic class: https://github.com/jqno/equalsverifier/blob/df5c50bd05eea3259cdbb5eac5b19813fea78e44/src/main/java/nl/jqno/equalsverifier/EqualsVerifierApi.java#L8

I hope this is not a problem as my proposed change is only to remove one redundant line and this change does not affect code behaviour in any way.

Thank you in advance!